### PR TITLE
fix: move types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haxball.js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A powerful library for interacting with the Haxball Headless API",
   "main": "src/index.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@koush/wrtc": "^0.5.3",
     "@peculiar/webcrypto": "^1.3.3",
+    "@types/haxball-headless-browser": "^0.1.0",
     "json5": "^2.2.1",
     "node-fetch": "^2.6.6",
     "pako": "^2.0.4",
@@ -25,7 +26,6 @@
   },
   "devDependencies": {
     "@mapbox/node-pre-gyp": "^1.0.9",
-    "@types/haxball-headless-browser": "^0.1.0",
     "mocha": "^9.2.2"
   },
   "repository": {


### PR DESCRIPTION
Types were not working as intended after `npm install haxball.js` (`haxball-headless-browser` package is missing when installed). 

They worked fine when importing local folder through `npm install ../haxball.js-local-dir`, so I missed that. 

Moving from dev dependencies to dependencies should allow shipping with the package and solving the problem.