### PR TITLE
Inherited haxball types set to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haxball.js",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "A powerful library for interacting with the Haxball Headless API",
   "main": "src/index.js",
   "types": "types/index.d.ts",
@@ -19,7 +19,7 @@
   "dependencies": {
     "@koush/wrtc": "^0.5.3",
     "@peculiar/webcrypto": "^1.3.3",
-    "@types/haxball-headless-browser": "^0.1.0",
+    "@types/haxball-headless-browser": "latest",
     "http-proxy-agent": "^5.0.0",
     "json5": "^2.2.1",
     "pako": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@koush/wrtc": "^0.5.3",
     "@peculiar/webcrypto": "^1.3.3",
-    "@types/haxball-headless-browser": "latest",
+    "@types/haxball-headless-browser": "^0.3.0",
     "http-proxy-agent": "^5.0.0",
     "json5": "^2.2.1",
     "pako": "^2.0.4",


### PR DESCRIPTION
When the coding a room with `haxball.js`, the types included within `haxball.js` take precedence over separately chosen `@types/haxball-headless-browser` version. Therefore user will run into typescript errors when using package and cannot solve them without manually changing types version in `node_modules/haxball.js/package.json` and `npm i`.

It happens, because `haxball.js` sources from original `@types/haxball-headless-browser` types and exposes `Promise<Headless>`.