### PR TITLE
perf: replace pako with native zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ HaxballJS({ proxy: "http://1.1.1.1:80", }).then((HBInit) => {...});
 - ws - Websocket Connection
 - json5 - JSON Helper Module
 - Node.js Web Crypto API - WebCrypto implementation
-- pako - ZLIB port for Node.JS
+- Node.js Zlib API - native compression support
 - xhr2 - W3C XMLHttpRequest implementation for Node.JS
 - https-proxy-agent - Websocket Proxy Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "haxball.js",
-	"version": "5.0.6",
+	"version": "5.0.7",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "haxball.js",
-			"version": "5.0.6",
+			"version": "5.0.7",
 			"license": "MIT",
 			"dependencies": {
 				"@webrtc-node/webrtc": "^0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,12 @@
 				"@webrtc-node/webrtc": "^0.2.1",
 				"https-proxy-agent": "^9.1.0",
 				"json5": "^2.2.3",
-				"pako": "^2.1.0",
 				"ws": "^8.18.3",
 				"xhr2": "^0.2.1"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.3",
 				"@types/node": "^22.20.1",
-				"@types/pako": "^2.0.4",
 				"@types/ws": "^8.18.1",
 				"simple-git-hooks": "^2.13.1",
 				"tsdown": "^0.22.4",
@@ -594,13 +592,6 @@
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
-		},
-		"node_modules/@types/pako": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
-			"integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/ws": {
 			"version": "8.18.1",
@@ -1371,12 +1362,6 @@
 			"engines": {
 				"node": ">=12.20.0"
 			}
-		},
-		"node_modules/pako": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-			"integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/picomatch": {
 			"version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.3",
 		"@types/node": "^22.20.1",
-		"@types/pako": "^2.0.4",
 		"@types/ws": "^8.18.1",
 		"simple-git-hooks": "^2.13.1",
 		"tsdown": "^0.22.4",
@@ -70,7 +69,6 @@
 		"@webrtc-node/webrtc": "^0.2.1",
 		"https-proxy-agent": "^9.1.0",
 		"json5": "^2.2.3",
-		"pako": "^2.1.0",
 		"ws": "^8.18.3",
 		"xhr2": "^0.2.1"
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haxball.js",
-	"version": "5.0.6",
+	"version": "5.0.7",
 	"author": "mertushka",
 	"description": "A powerful library for interacting with the Haxball Headless API",
 	"keywords": [

--- a/src/pako.ts
+++ b/src/pako.ts
@@ -1,0 +1,107 @@
+import {
+	constants,
+	deflateRawSync,
+	inflateRawSync,
+	type ZlibOptions,
+} from 'node:zlib'
+
+type Input = string | ArrayBuffer | NodeJS.ArrayBufferView
+
+function toUint8Array(data: Uint8Array): Uint8Array {
+	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+}
+
+export function deflateRaw(data: Input): Uint8Array {
+	return toUint8Array(deflateRawSync(data))
+}
+
+export function inflateRaw(data: Input): Uint8Array {
+	return toUint8Array(inflateRawSync(data))
+}
+
+export class Inflate {
+	err = 0
+	msg = ''
+	result?: Uint8Array
+
+	readonly #options: ZlibOptions
+	#chunks: Uint8Array[] = []
+
+	constructor(options: ZlibOptions & { raw?: boolean } = {}) {
+		const { raw: _raw, ...zlibOptions } = options
+		this.#options = zlibOptions
+	}
+
+	onData(chunk: Uint8Array): void {
+		this.#chunks.push(chunk)
+	}
+
+	onEnd(status: number): void {
+		this.err = status
+		if (status === 0) {
+			this.result = this.#chunks.length === 1 ? this.#chunks[0] : undefined
+		}
+		this.#chunks = []
+	}
+
+	push(data: Input, final: boolean): boolean {
+		if (!final) {
+			throw new Error('The Node zlib compatibility adapter requires final=true')
+		}
+
+		const outputBuffer = (this as { buffer?: unknown }).buffer
+		const maxOutputLength =
+			outputBuffer instanceof Uint8Array
+				? Math.max(1, outputBuffer.byteLength)
+				: undefined
+		const chunkSize =
+			maxOutputLength === undefined
+				? this.#options.chunkSize
+				: (this.#options.chunkSize ??
+					Math.max(constants.Z_MIN_CHUNK, maxOutputLength))
+
+		let output: Uint8Array
+		try {
+			output = toUint8Array(
+				inflateRawSync(data, {
+					...this.#options,
+					chunkSize,
+					maxOutputLength,
+				}),
+			)
+		} catch (error) {
+			if (
+				maxOutputLength !== undefined &&
+				error instanceof Error &&
+				'code' in error &&
+				error.code === 'ERR_BUFFER_TOO_LARGE'
+			) {
+				throw new Error('Inflate size exceeds limit')
+			}
+
+			this.msg = error instanceof Error ? error.message : String(error)
+			const status =
+				error instanceof Error &&
+				'errno' in error &&
+				typeof error.errno === 'number'
+					? error.errno
+					: constants.Z_DATA_ERROR
+			this.onEnd(status)
+			return false
+		}
+
+		this.onData(output)
+		this.onEnd(0)
+		return true
+	}
+}
+
+interface PakoAdapter {
+	deflateRaw: typeof deflateRaw
+	inflateRaw: typeof inflateRaw
+	Inflate: typeof Inflate
+}
+
+const pako: PakoAdapter = { deflateRaw, inflateRaw, Inflate }
+
+export default pako

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,11 +1,11 @@
 import * as WebRTCNode from '@webrtc-node/webrtc'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 import JSON5 from 'json5'
-import pako from 'pako'
 import WebSocket from 'ws'
 // @ts-expect-error xhr2 does not publish TypeScript declarations.
 import XMLHttpRequest from 'xhr2'
 
+import pako from './pako.ts'
 import type { HBInit } from './types.ts'
 
 type Constructor = new (...args: never[]) => object

--- a/test/pako.test.ts
+++ b/test/pako.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { constants } from 'node:zlib'
+
+import pako from '../src/pako.ts'
+
+const source = new TextEncoder().encode('native zlib '.repeat(1_000))
+
+test('raw deflate and inflate round trip as Uint8Array values', () => {
+	const compressed = pako.deflateRaw(source)
+	const restored = pako.inflateRaw(compressed)
+
+	assert.ok(compressed instanceof Uint8Array)
+	assert.ok(restored instanceof Uint8Array)
+	assert.equal(compressed.constructor, Uint8Array)
+	assert.equal(restored.constructor, Uint8Array)
+	assert.deepEqual(restored, source)
+})
+
+test('Inflate supports subclass callbacks and synchronous final push', () => {
+	class BoundedInflate extends pako.Inflate {
+		readonly buffer = new Uint8Array(source.length)
+		total = 0
+		endedWith: number | undefined
+		readonly callbacks: string[] = []
+
+		override onData(chunk: Uint8Array) {
+			this.callbacks.push('data')
+			this.buffer.set(chunk, this.total)
+			this.total += chunk.byteLength
+		}
+
+		override onEnd(status: number) {
+			this.callbacks.push('end')
+			this.endedWith = status
+			this.err = status
+		}
+	}
+
+	const inflate = new BoundedInflate({ raw: true })
+	assert.equal(inflate.push(pako.deflateRaw(source), true), true)
+	assert.equal(inflate.endedWith, 0)
+	assert.equal(inflate.err, 0)
+	assert.equal(inflate.total, source.length)
+	assert.deepEqual(inflate.callbacks, ['data', 'end'])
+	assert.deepEqual(inflate.buffer, source)
+})
+
+test('Inflate default callbacks expose the result and success state', () => {
+	const inflate = new pako.Inflate({ raw: true })
+
+	assert.equal(inflate.push(pako.deflateRaw(source), true), true)
+	assert.equal(inflate.err, 0)
+	assert.equal(inflate.msg, '')
+	assert.ok(inflate.result instanceof Uint8Array)
+	assert.deepEqual(inflate.result, source)
+})
+
+test('Inflate reports malformed input through onEnd, err, and msg', () => {
+	const statuses: number[] = []
+	class CallbackInflate extends pako.Inflate {
+		override onData() {
+			assert.fail('onData must not run for malformed input')
+		}
+
+		override onEnd(status: number) {
+			statuses.push(status)
+			super.onEnd(status)
+		}
+	}
+
+	const inflate = new CallbackInflate({ raw: true })
+	assert.equal(inflate.push(Uint8Array.of(0xff), true), false)
+	assert.equal(inflate.err, constants.Z_DATA_ERROR)
+	assert.notEqual(inflate.msg, '')
+	assert.deepEqual(statuses, [inflate.err])
+})
+
+test('Inflate enforces an upstream-style output buffer limit', () => {
+	class BoundedInflate extends pako.Inflate {
+		readonly buffer = new Uint8Array(source.length - 1)
+	}
+
+	const inflate = new BoundedInflate({ raw: true })
+	assert.throws(
+		() => inflate.push(pako.deflateRaw(source), true),
+		/Inflate size exceeds limit/,
+	)
+})
+
+test('Inflate propagates callback errors', () => {
+	class DataCallbackInflate extends pako.Inflate {
+		override onData() {
+			throw new Error('callback failed')
+		}
+	}
+
+	class EndCallbackInflate extends pako.Inflate {
+		override onEnd() {
+			throw new Error('end callback failed')
+		}
+	}
+
+	const compressed = pako.deflateRaw(source)
+	const inflate = new DataCallbackInflate({ raw: true })
+	assert.throws(() => inflate.push(compressed, true), /callback failed/)
+	assert.throws(
+		() => new EndCallbackInflate({ raw: true }).push(compressed, true),
+		/end callback failed/,
+	)
+})
+
+test('Inflate enforces a zero-length output buffer limit', () => {
+	class BoundedInflate extends pako.Inflate {
+		readonly buffer = new Uint8Array(0)
+
+		override onData(chunk: Uint8Array) {
+			if (chunk.byteLength > this.buffer.byteLength) {
+				throw new Error('Inflate size exceeds limit')
+			}
+		}
+	}
+
+	const inflate = new BoundedInflate({ raw: true })
+	assert.throws(
+		() => inflate.push(pako.deflateRaw(Uint8Array.of(1)), true),
+		/Inflate size exceeds limit/,
+	)
+})


### PR DESCRIPTION
## Summary

- replace Pako with a small Pako-compatible adapter backed by native `node:zlib`
- preserve the generated headless source's expected injection API and decompression-size protection
- remove `pako` and `@types/pako`, update documentation, and release as v5.0.7

## Why

The generated HaxBall source only needs raw synchronous deflate/inflate plus a subclassable synchronous `Inflate`. Native Node zlib provides the same required behavior with substantially lower CPU usage and no bundled JavaScript compression dependency.

## Implementation

The adapter preserves `deflateRaw`, `inflateRaw`, `Inflate`, `push(data, true)`, `onData`, `onEnd`, `err`, and Pako-compatible zlib error numbers. Bounded inflation uses native `maxOutputLength`, aligns `chunkSize` with the known output limit, returns zero-copy plain `Uint8Array` views, and propagates callback exceptions. The generated upstream source is unchanged.

## Validation

- clean `npm ci` and production audit with zero vulnerabilities
- lint, type-check, build, and 20 tests passed
- coverage: 96.17% overall and 98.13% for the adapter
- Node 22.18 minimum-runtime suite passed
- ESM and CommonJS package consumers passed
- Publint and Are the Types Wrong reported no problems
- packed release contents and native `node:zlib` imports inspected
